### PR TITLE
enable macOS (Apple Silicon/Intel) support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,22 @@ Please cite the following paper if you use gkm-align:
 Also, visit the [gkm-align webpage](https://beerlab.org/gkmalign/) to find useful resource files for running gkm-align. 
 
 # System Requirements
-gkm-align is designed for Linux-based operating systems (Red Hat, CentOS, Rocky Linux, etc.).
-**Tested on:** Rocky Linux release 8.8 (Green Obsidian)
+gkm-align is designed for **Linux** (Red Hat, CentOS, Ubuntu, etc.) and **macOS** (Apple Silicon).
+**Tested on:** Rocky Linux release 8.8 (Green Obsidian) and macOS Sonoma (Apple M3 Pro).
 
 **SIMD Requirements:**
-- **AVX2 support**: Maximum lmer length = 32
-- **SSE2 support**: Maximum lmer length = 16
+* **AVX2 support** (Intel/AMD): Maximum lmer length = 32
+* **SSE2 support** (Intel/AMD): Maximum lmer length = 16
+* **ARM NEON support** (Apple Silicon): Maximum lmer length = 16
 
 **Check your system's SIMD support:**
-- AVX2: `lscpu | grep avx2`
-- SSE2: `lscpu | grep sse2`
+* **Linux:** `lscpu | grep -E "avx2|sse2"`
+* **macOS:** `sysctl -a | grep neon`
 
-**Without SIMD support:** You can only use mapping mode (-t 2) with precomputed genome alignment files (e.g., [hg38-mm10_unweighted.coord](https://beerlab.org/gkmalign/hg38-mm10_unweighted.coord))
+**Without SIMD support:**
+You can only use mapping mode (`-t 2`) with precomputed genome alignment files (e.g., [hg38-mm10_unweighted.coord](https://beerlab.org/gkmalign/hg38-mm10_unweighted.coord)).
 
-**Note:** Attempting to use alignment mode (-t 1) without SIMD support will result in an error during argument parsing.
+**Note:** Attempting to use alignment mode (`-t 1`) without SIMD support (AVX2, SSE2, or NEON) will result in an error during argument parsing.
 
  
 # Installation

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Also, visit the [gkm-align webpage](https://beerlab.org/gkmalign/) to find usefu
 
 # System Requirements
 gkm-align is designed for **Linux** (Red Hat, CentOS, Ubuntu, etc.) and **macOS** (Apple Silicon).
-**Tested on:** Rocky Linux release 8.8 (Green Obsidian) and macOS Sonoma (Apple M3 Pro).
+
+**Tested on:** Rocky Linux release 8.8 (Green Obsidian) and macOS Sequoia (Apple M3 Pro).
 
 **SIMD Requirements:**
 * **AVX2 support** (Intel/AMD): Maximum lmer length = 32

--- a/README.md
+++ b/README.md
@@ -32,23 +32,29 @@ Please cite the following paper if you use gkm-align:
 Also, visit the [gkm-align webpage](https://beerlab.org/gkmalign/) to find useful resource files for running gkm-align. 
 
 # System Requirements
-gkm-align is designed for **Linux** (Red Hat, CentOS, Ubuntu, etc.) and **macOS** (Apple Silicon).
+**Supported OS:** Linux (CentOS, Ubuntu, Rocky Linux, etc.) and macOS (Apple Silicon).
+**Tested on:** Rocky Linux 8.8 and macOS Sequoia (Apple M3 Pro).
 
-**Tested on:** Rocky Linux release 8.8 (Green Obsidian) and macOS Sequoia (Apple M3 Pro).
+### Hardware Acceleration (SIMD)
+gkm-align automatically detects your CPU architecture (AVX2, SSE2, or ARM NEON) to optimize alignment speed.
 
-**SIMD Requirements:**
-* **AVX2 support** (Intel/AMD): Maximum lmer length = 32
-* **SSE2 support** (Intel/AMD): Maximum lmer length = 16
-* **ARM NEON support** (Apple Silicon): Maximum lmer length = 16
+**Note on Parameter Limits:**
+Your hardware determines the maximum gapped-kmer length (`-l`) you can use:
+* **Most Laptops (Apple Silicon / Older Intel):** Supports `-l` up to **16**.
+* **Modern Servers (Intel/AMD with AVX2):** Supports `-l` up to **32**.
 
-**Check your system's SIMD support:**
+*Note: The default length is 11, which works on all supported systems.*
+
+<details>
+<summary><strong>Click here to manually check your hardware support</strong></summary>
+
+If you need to verify which instruction set your CPU supports:
 * **Linux:** `lscpu | grep -E "avx2|sse2"`
 * **macOS:** `sysctl -a | grep neon`
 
-**Without SIMD support:**
-You can only use mapping mode (`-t 2`) with precomputed genome alignment files (e.g., [hg38-mm10_unweighted.coord](https://beerlab.org/gkmalign/hg38-mm10_unweighted.coord)).
-
-**Note:** Attempting to use alignment mode (`-t 1`) without SIMD support (AVX2, SSE2, or NEON) will result in an error during argument parsing.
+**Troubleshooting:**
+If your system lacks SIMD support entirely (rare), you can only use mapping mode (`-t 2`). Attempting alignment mode (`-t 1`) will result in an error.
+</details>
 
  
 # Installation

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Also, visit the [gkm-align webpage](https://beerlab.org/gkmalign/) to find usefu
 
 # System Requirements
 **Supported OS:** Linux (CentOS, Ubuntu, Rocky Linux, etc.) and macOS (Apple Silicon).
+
 **Tested on:** Rocky Linux 8.8 and macOS Sequoia (Apple M3 Pro).
 
 ### Hardware Acceleration (SIMD)

--- a/examples/FADS_cluster/run_gkmalign.sh
+++ b/examples/FADS_cluster/run_gkmalign.sh
@@ -9,7 +9,7 @@ mkdir output_files
 
 
 # align FADS locus. -G option outputs matrix G containing pairwise sequence similarity (gkm-sim matrix)
-../../bin/gkm_align  -t 1  FADS_loci.to_align -d ../../data/genomes/ -g masker_models.txt   -p 50 -o output_files -n FADS_loci_mm10-hg38 -G
+../../bin/gkm_align  -t 1 -d ../../data/genomes/ -g masker_models.txt   -p 50 -o output_files -n FADS_loci_mm10-hg38 -G FADS_loci.to_align 
 
 
 

--- a/examples/HBB_LCR/run_gkmalign.sh
+++ b/examples/HBB_LCR/run_gkmalign.sh
@@ -6,8 +6,8 @@ echo "../../data/human_genomic_background_model_p_0.1.out" >> masker_models.txt
 
 
 mkdir output_files
-../../bin/gkm_align  -t 1  HBB.to_align -d ../../data/genomes/ -g masker_models.txt   -p 50 -o output_files -n HBB_LCR_mm10-hg38
-../../bin/gkm_align  -t 2  HBB_LCR_enhancers_mm10.bed  -c output_files/HBB_LCR_mm10-hg38.coord -q mm10 -m -o output_files -n HBB_LCR_enhancers_mm10_mapped_to_hg38 
+../../bin/gkm_align  -t 1 -d ../../data/genomes/ -g masker_models.txt   -p 50 -o output_files -n HBB_LCR_mm10-hg38 HBB.to_align
+../../bin/gkm_align  -t 2 -c output_files/HBB_LCR_mm10-hg38.coord -q mm10 -m -o output_files -n HBB_LCR_enhancers_mm10_mapped_to_hg38 HBB_LCR_enhancers_mm10.bed
 
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,78 +1,143 @@
 #!/bin/sh
 
-# Check OS first - only allow Linux
+# 1. Detect OS and Architecture
 OS_CHECK=$(uname -s)
-if [ "$OS_CHECK" != "Linux" ]; then
-    echo "Error: This software is designed for Linux systems only."
-    echo "Detected OS: $OS_CHECK"
-    echo "Please use a Linux system with x86/x64 architecture."
+ARCH_CHECK=$(uname -m)
+
+echo "Detected System: $OS_CHECK ($ARCH_CHECK)"
+
+if [ "$OS_CHECK" != "Linux" ] && [ "$OS_CHECK" != "Darwin" ]; then
+    echo "Error: This software is designed for Linux or macOS."
+    echo "Detected: $OS_CHECK"
     exit 1
 fi
 
-echo "Linux system detected. Proceeding with compilation..."
-echo "Checking SIMD support..."
-echo "This software requires either AVX2 or SSE2 SIMD support."
-echo "Checking for AVX2 support first, falling back to SSE2 if needed..."
+# 2. Check Compiler & SIMD Support
+echo "Checking compilation environment..."
 
-# Check if we can compile with at least SSE2 (optional check)
-if ! g++ -msse2 -x c++ -o /dev/null - <<< 'int main() { __m128i x; return 0; }' 2>/dev/null; then
-    echo "Warning: This system does not support SSE2 SIMD instructions."
-    echo "gkm-align will compile but -t 1 (genome alignment) will not be available."
-    echo "-t 2 (enhancer mapping) will still work with precomputed alignment files."
-    echo "Proceeding with compilation..."
+# Define a temporary test file
+TEST_SRC="simd_check.cpp"
+
+if echo "$ARCH_CHECK" | grep -q "arm64"; then
+    # --- ARM Logic (Apple Silicon / Graviton) ---
+    echo "ARM64 architecture detected. Verifying NEON support..."
+    cat <<EOF > $TEST_SRC
+#include <arm_neon.h>
+int main() { uint8x16_t x = vdupq_n_u8(0); return 0; }
+EOF
+    # Try compiling (Mac clang defaults to neon, no flags needed usually)
+    if ! g++ $TEST_SRC -o /dev/null 2>/dev/null; then
+        echo "Warning: Could not compile ARM NEON code."
+        echo "Ensure you have Xcode Command Line Tools installed (xcode-select --install)."
+        SKIP_ALIGN="true"
+    else
+        echo "NEON support confirmed."
+    fi
+
 else
-    echo "SIMD support confirmed. All options will be available."
+    # --- Intel/AMD Logic (x86_64) ---
+    echo "x86_64 architecture detected. Verifying SSE2/AVX2 support..."
+    cat <<EOF > $TEST_SRC
+#include <emmintrin.h>
+int main() { __m128i x = _mm_setzero_si128(); return 0; }
+EOF
+    # Try compiling with SSE2 flag
+    if ! g++ -msse2 $TEST_SRC -o /dev/null 2>/dev/null; then
+        echo "Warning: This system does not support SSE2 SIMD instructions."
+        SKIP_ALIGN="true"
+    else
+        echo "SSE2/AVX2 support confirmed."
+    fi
 fi
 
-# compile gkm-align
+# Clean up test file
+rm -f $TEST_SRC
+
+if [ "$SKIP_ALIGN" = "true" ]; then
+    echo "gkm-align will compile, but Alignment Mode (-t 1) will be disabled due to lack of SIMD."
+    echo "Mapping Mode (-t 2) will still work."
+fi
+
+echo "Proceeding with compilation..."
+
+# 3. Compile
 cd src
 make clean
 make
 cd ..
 
+# --- Helper Function for Downloads (Handles wget vs curl) ---
+download_file() {
+    # Usage: download_file <URL> <OUTPUT_NAME> (Optional)
+    URL=$1
+    OUT=$2
+    
+    if command -v wget >/dev/null 2>&1; then
+        if [ -z "$OUT" ]; then
+            wget -q "$URL"
+        else
+            wget -q "$URL" -O "$OUT"
+        fi
+    elif command -v curl >/dev/null 2>&1; then
+        if [ -z "$OUT" ]; then
+            curl -s -L -O "$URL"
+        else
+            curl -s -L "$URL" -o "$OUT"
+        fi
+    else
+        echo "Error: Neither wget nor curl found. Cannot download files."
+        exit 1
+    fi
+}
 
+# 4. Download Background Models
+mkdir -p data
+printf "\nDownloading hg38 and mm10 genome background models to data/...\n"
 
-# download genome background models 
-mkdir data
-printf "\nhg38, mm10 genome background models downloaded to data/. \n"
-wget -q https://beerlab.org/gkmalign/masker_model_hg38_outside_union_repr_kmer_cluster_threshold_pieces_p_0.1.out -O data/human_genomic_background_model_p_0.1.out 
-wget -q https://beerlab.org/gkmalign/masker_model_mm10_outside_union_repr_kmer_cluster_threshold_pieces_p_0.1.out -O data/mouse_genomic_background_model_p_0.1.out
+download_file "https://beerlab.org/gkmalign/masker_model_hg38_outside_union_repr_kmer_cluster_threshold_pieces_p_0.1.out" "data/human_genomic_background_model_p_0.1.out"
+download_file "https://beerlab.org/gkmalign/masker_model_mm10_outside_union_repr_kmer_cluster_threshold_pieces_p_0.1.out" "data/mouse_genomic_background_model_p_0.1.out"
 
+echo "Models downloaded."
 
-
-# download genomes 
+# 5. Download Genomes (Optional Loop)
 while true; do
-	printf "\nDownload hg38 and mm10 genomes? (y/n) \n"
-	read -p "y recommended for the github tutorial (~6 gigabytes).   " yn
-	case $yn in
-	[Yy]* )
-	 cd data
-	 mkdir genomes
-	 cd genomes
-	 mkdir hg38
-	 mkdir mm10
+    printf "\nDownload hg38 and mm10 genomes? (y/n) \n"
+    read -p "y recommended for the github tutorial (~6 gigabytes).   " yn
+    case $yn in
+        [Yy]* )
+            mkdir -p data/genomes/hg38
+            mkdir -p data/genomes/mm10
 
-	 cd hg38
-	 printf "\nDownloading hg38 to data/genomes/.\n"
-	 for c in {1..22} X Y M 
-	 do
-	     printf "chr${c}\n"
-	     wget -q  "https://hgdownload.cse.ucsc.edu/goldenPath/hg38/chromosomes/chr${c}.fa.gz"
-	 done
-	 gunzip *.fa.gz
+            # Download hg38
+            cd data/genomes/hg38
+            printf "\nDownloading hg38 to data/genomes/hg38/...\n"
+            for c in {1..22} X Y M 
+            do
+                printf "chr${c} "
+                download_file "https://hgdownload.cse.ucsc.edu/goldenPath/hg38/chromosomes/chr${c}.fa.gz"
+            done
+            printf "\nUnzipping hg38...\n"
+            gunzip -f *.fa.gz
 
-	 cd ../mm10
-	 printf "\nDownloading mm10 to data/genomes/.\n"
-	 for c in {1..19} X Y M
-	 do
-             printf "chr${c}\n"
-	     wget -q "https://hgdownload.cse.ucsc.edu/goldenPath/mm10/chromosomes/chr${c}.fa.gz"
-         done
-	 gunzip *.fa.gz
-	 cd ../../../../
-	 break;;
-	[Nn]* ) exit;;
-	* ) printf "enter y or n; Download hg38 and mm10 genomes?\n";;
-	esac
+            # Download mm10
+            cd ../mm10
+            printf "\nDownloading mm10 to data/genomes/mm10/...\n"
+            for c in {1..19} X Y M
+            do
+                printf "chr${c} "
+                download_file "https://hgdownload.cse.ucsc.edu/goldenPath/mm10/chromosomes/chr${c}.fa.gz"
+            done
+            printf "\nUnzipping mm10...\n"
+            gunzip -f *.fa.gz
+            
+            cd ../../../
+            printf "\nDownload complete.\n"
+            break;;
+            
+        [Nn]* ) 
+            exit;;
+            
+        * ) 
+            printf "Please enter y or n.\n";;
+    esac
 done
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,36 +1,39 @@
-# Use CXX for C++ compilers (Standard convention)
+# Makefile
 CXX = g++
-
-# 1. CRITICAL: Added -O3 for performance
-# 2. Changed CFLAGS to CXXFLAGS (Standard for C++)
 COMMON_FLAGS = -std=c++11 -Wall -Wextra -pedantic -pthread -O3
 BIN_DIR = ../bin
 
-# OS Check
-OS_CHECK = $(shell uname -s)
-ifneq ($(OS_CHECK),Linux)
-    $(error This software is designed for Linux systems only.)
-endif
+# --- OS & Architecture Detection ---
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
 
-# --- SIMD Detection ---
-# Note: This detects the BUILD machine's CPU. 
-# If you run this on a cluster node with AVX2, the binary might crash 
-# if moved to an older node without AVX2.
+# 1. Detect Hardware Features
+# Linux uses lscpu; Mac (Darwin) implies hardware based on arch
 HAS_AVX2 := $(shell lscpu 2>/dev/null | grep -q avx2 && echo 1)
 HAS_SSE2 := $(shell lscpu 2>/dev/null | grep -q sse2 && echo 1)
+IS_ARM64 := $(shell echo $(UNAME_M) | grep -q 'arm64' && echo 1)
 
+# 2. Set Flags
 ifeq ($(HAS_AVX2),1)
+    # Standard Intel/AMD Server
     CXXFLAGS = $(COMMON_FLAGS) -mavx2
     SIMD_DEFINE = -D__AVX2__
-    MSG = AVX2 (Fastest)
+    MSG = AVX2 (Intel/AMD)
 else ifeq ($(HAS_SSE2),1)
+    # Older Intel
     CXXFLAGS = $(COMMON_FLAGS) -msse2
     SIMD_DEFINE = -D__SSE2__
-    MSG = SSE2 (Fallback)
+    MSG = SSE2 (Intel Fallback)
+else ifeq ($(IS_ARM64),1)
+    # Apple Silicon (M1/M2/M3) or AWS Graviton
+    CXXFLAGS = $(COMMON_FLAGS)
+    SIMD_DEFINE = -D__ARM_NEON
+    MSG = ARM NEON (Apple Silicon)
 else
+    # Ancient Hardware
     CXXFLAGS = $(COMMON_FLAGS)
     SIMD_DEFINE = -D__NOSIMD__
-    MSG = No SIMD (Slowest)
+    MSG = No SIMD
 endif
 
 # --- Targets ---

--- a/src/Seq_Aligner.cpp
+++ b/src/Seq_Aligner.cpp
@@ -158,15 +158,12 @@ Seq_Aligner::backtrack(float indel) {
             dots.insert(dots.begin(), dot);
             --i;
             --j;
-            num_match++;
 
         } else if (indel1) {
             --i;
-            num_skip++;
 
         } else if (indel2) {
             --j;
-            num_skip++;
 
         } else { // for debug.
             cout << "Unexpected event (debug needed)" << endl;

--- a/src/Seq_Aligner.cpp
+++ b/src/Seq_Aligner.cpp
@@ -46,7 +46,6 @@ Seq_Aligner::Seq_Aligner(Matrix* G, vector<float>* ann_vector_1, vector<float>* 
   K(km_dim_1, km_dim_2),
   DM(dm_dim_1, dm_dim_2, numeric_limits<float>::infinity()),
   rel_strand_loc(rel_strand_loc),
-  wF(wF),
   type(2),
   ID_2align(ID_2align)
 
@@ -139,8 +138,6 @@ Seq_Aligner::backtrack(float indel) {
 
     tuple<int, int> dot;
 
-    int num_match = 0;
-    int num_skip = 0;
     while (i > 0 || j > 0) {
         // Boolean values that encode which 'directions' are possible
         bool match = ((i > 0 && j > 0) &&
@@ -213,7 +210,6 @@ Seq_Aligner::dots_to_coords(
     vector<tuple<int, int, string, string,string>> coords;
     tuple<int, int, string, string, string> coord;
     int i; int j; string Gval; string aV_elem_1 = "."; string aV_elem_2 = ".";
-    tuple<float,float> vals;
     for (auto &dot : dots) {
         i = get<0>(dot); j = get<1>(dot);
         if(rel_strand_loc == "same_strand"){

--- a/src/header.h
+++ b/src/header.h
@@ -20,7 +20,10 @@
 #include <immintrin.h>
 #elif defined(__SSE2__)
 #include <emmintrin.h>
+#elif defined(__ARM_NEON) 
+#include <arm_neon.h>
 #endif
+
 using namespace std; 
 
 
@@ -239,7 +242,6 @@ class Seq_Aligner{
 	Matrix K;
         Matrix DM; // dynamic matrix 
         string rel_strand_loc;
-        float wF;
 	int type;
 	float mean;
 	float var;

--- a/test/test_hbb_lcr.sh
+++ b/test/test_hbb_lcr.sh
@@ -38,8 +38,8 @@ echo "../data/mouse_genomic_background_model_p_0.1.out" > masker_models.txt
 echo "../data/human_genomic_background_model_p_0.1.out" >> masker_models.txt
 
 # Run gkm-align
-../bin/gkm_align -t 1 HBB.to_align -d ../data/genomes/ -g masker_models.txt -p 50 -o output_files -n HBB_LCR_mm10-hg38
-../bin/gkm_align -t 2 HBB_LCR_enhancers_mm10.bed -c output_files/HBB_LCR_mm10-hg38.coord -q mm10 -m -o output_files -n HBB_LCR_enhancers_mm10_mapped_to_hg38
+../bin/gkm_align -t 1  -d ../data/genomes/ -g masker_models.txt -p 50 -o output_files -n HBB_LCR_mm10-hg38 HBB.to_align
+../bin/gkm_align -t 2  -c output_files/HBB_LCR_mm10-hg38.coord -q mm10 -m -o output_files -n HBB_LCR_enhancers_mm10_mapped_to_hg38 HBB_LCR_enhancers_mm10.bed
 
 # Compare results
 echo "Comparing results..."


### PR DESCRIPTION
- added full support for macOS (specifically optimizing for Apple Silicon via ARM NEON SIMD) while maintaining backward compatibility with Linux (AVX2/SSE2).

- also modernized the build/setup scripts and resolves several compiler warnings.